### PR TITLE
Add visualization capability for aider bench results

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Included scripts:
 
 ## Usage
 1. Clone the repo with `acquire_data.py`
-2. Add your evaluation results (must include `output.jsonl` and `report.json` files) to the `od_eval` folder
+2. Add your evaluation results (must include `output.jsonl` and `report.json` files for swe-bench or `output.jsonl` for aider bench) to the `od_eval` folder
 3. Add your Zeno API Key
 4. Run `visualize_results.py` to generate visualizations

--- a/data_utils.py
+++ b/data_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 
 def load_data(file_path):
@@ -17,3 +18,30 @@ def load_data(file_path):
             resolved = 1 if instance in resolved_ids else 0
             data_list.append((instance, problem_statement, resolved))
     return data_list
+
+def load_data_aider_bench(file_path):
+    data_list = []
+    directory_name = os.path.dirname(file_path)
+    print("Directory name: ", directory_name)
+    with open(file_path, "r") as file:
+        for line in file:
+            data = json.loads(line)
+            instance_id = data.get("instance_id")
+            test_result = data.get("test_result",{})
+            resolved = 1 if test_result.get("exit_code")==0 and bool(re.fullmatch(r'\.+', test_result.get("test_cases"))) else 0
+            test_cases = test_result.get("test_cases")
+            instruction = data.get("instruction")
+            agent_trajectory = []
+            for step in data.get("history", []):
+                if step[0]["source"] != "agent":
+                    continue
+                agent_trajectory.append({"action": step[0].get("action"), "code":step[0].get("args",{}).get("code"),"thought":step[0].get("args",{}).get("thought"),"observation":step[1].get("message")})
+            data_list.append((instance_id, instruction, resolved, test_cases, agent_trajectory))
+
+    return data_list
+
+def get_model_name_aider_bench(file_path):
+    with open(file_path, "r") as file:
+        first_line = file.readline()
+        data = json.loads(first_line)
+        return data.get("metadata", {}).get("llm_config", {}).get("model").split("/")[-1]

--- a/visualize_results.py
+++ b/visualize_results.py
@@ -2,13 +2,13 @@
 
 import os
 import re
-from data_utils import load_data
+from data_utils import load_data, load_data_aider_bench, get_model_name_aider_bench
 import argparse
 import zeno_client
 import pandas as pd
 
 
-def main(input_files: list[str]):
+def visualise_swe_bench(input_files: list[str]):
     """Visualize data from multiple input files."""
     data = [load_data(input_file) for input_file in input_files]
     ids = [x[0] for x in data[0]]
@@ -74,11 +74,87 @@ def main(input_files: list[str]):
             df_system, name=model_name, id_column="id", output_column="resolved"
         )
 
+def visualize_aider_bench(input_files: list[str]):
+    """Visualize data from multiple input files."""
+    data = [load_data_aider_bench(input_file) for input_file in input_files]
+    ids = [x[0] for x in data[0]]
+    id_map = {x: i for (i, x) in enumerate(ids)}
+
+    # Find all duplicate values in "ids"
+    seen = set()
+    duplicates = set()
+    for x in ids:
+        if x in seen:
+            duplicates.add(x)
+        seen.add(x)
+    print(duplicates)
+
+    vis_client, vis_project = None, None
+    print(os.environ.get("ZENO_API_KEY"))
+    vis_client = zeno_client.ZenoClient(os.environ.get("ZENO_API_KEY"))
+
+    # use zeno to visualize
+    df_data = pd.DataFrame(
+        {
+            "id": ids,
+            "instruction": [x[1] for x in data[0]],
+        },
+        index=ids,
+    )
+    df_data["instruction_length"] = df_data["instruction"].apply(len)
+    #df_data["repo"] = df_data["id"].str.rsplit("-", n=1).str[0]
+    vis_project = vis_client.create_project(
+        name="Aider Bench Code Editing Visualization",
+        view={
+            "data": {"type": "markdown"},
+            "label": {"type": "text"},
+            "output": {"type": "markdown"}
+        },
+        description="Aider Bench Code Editing",
+        public=False,
+        metrics=[
+            zeno_client.ZenoMetric(name="resolved", type="mean", columns=["resolved"]),
+        ],
+    )
+    vis_project.upload_dataset(
+        df_data,
+        id_column="id",
+        data_column="instruction"
+    )
+
+    # Do evaluation
+    for input_file, data_entry in zip(input_files, data):
+        output = [''] * len(data[0])
+        for entry in data_entry:
+            output[id_map[entry[0]]] += f'## Resolved\n {entry[2]} \n ## Test Cases\n {entry[3]}\n ## Agent Trajectory\n'
+            for i in range(len(entry[4])):
+                output[id_map[entry[0]]] += f'### Step {i+1} \n'
+                output[id_map[entry[0]]] += f'Action: {entry[4][i]["action"]}\n'
+                output[id_map[entry[0]]] += f'Code: {entry[4][i]["code"]}\n'
+                output[id_map[entry[0]]] += f'Thought: {entry[4][i]["thought"]}\n'
+                output[id_map[entry[0]]] += f'Observation: {entry[4][i]["observation"]}\n'
+
+        df_system = pd.DataFrame(
+            {
+                "id": ids,
+                "agent output": output,
+            },
+            index=ids,
+        )
+
+        vis_project.upload_system(
+            df_system, name=get_model_name_aider_bench(input_file), id_column="id", output_column="agent output"
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Visualize results from SWE-bench experiments."
     )
     parser.add_argument("input_files", help="Path to multiple input files", nargs="+")
+    parser.add_argument("benchmark", help="Benchmark to visualize", type=str, choices=["swe-bench", "aider-bench"], default="swe-bench")
     args = parser.parse_args()
-    main(args.input_files)
+    if args.benchmark == "swe-bench":
+        visualise_swe_bench(args.input_files)
+    else:
+        visualize_aider_bench(args.input_files)


### PR DESCRIPTION
- Add load_data_aider_bench and get_model_name_aider_bench in the data_util.py file to handle loading data and model name from the output.jsonl file.
- Add visualize_aider_bench to visualize_results.py file to setup visualization on Zeno.
- Update args to switch between aider-bench and swe-bench