### PR TITLE
SWE-bench leaderboard visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .requirements.txt.swp
+**/__pycache__
+.venv
+.mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/__pycache__
 .venv
 .mypy_cache
+poetry.lock

--- a/leaderboard_to_zeno.py
+++ b/leaderboard_to_zeno.py
@@ -1,0 +1,89 @@
+"""
+Convert the current SWE-bench leaderboard to a Zeno project.
+"""
+
+from datetime import datetime
+
+import pandas as pd
+import click
+import zeno_client
+from swe_bench.models import Split, Dataset, Evaluation
+from swe_bench.utilities import get_all_entries
+
+
+@click.command()
+@click.option(
+    "--split",
+    type=click.Choice(["lite", "verified", "test"]),
+    default="verified",
+    callback=lambda _ctx, _param, value: Split.from_str(value),
+)
+@click.option("--zeno-api-key", type=str, envvar="ZENO_API_KEY")
+def main(split: Split, zeno_api_key: str | None) -> None:
+    """
+    Convert the current leaderboard entries to a Zeno project.
+    """
+    # Build the Zeno client.
+    assert zeno_api_key, "No Zeno API key found."
+    viz_client = zeno_client.ZenoClient(zeno_api_key)
+
+    # Create a new project.
+    current_time = datetime.now()
+    viz_project = viz_client.create_project(
+        name=f"SWE-bench Leaderboard ({current_time})",
+        view={
+            "data": {"type": "markdown"},
+            "label": {"type": "text"},
+            "output": {"type": "code"},
+        },
+        description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",
+        public=True,
+        metrics=[
+            zeno_client.ZenoMetric(name="resolved", type="mean", columns=["resolved"])
+        ],
+    )
+
+    # Build and upload the dataset.
+    dataset = Dataset.from_split(split)
+    viz_project.upload_dataset(
+        pd.DataFrame([instance.model_dump() for instance in dataset.instances]),
+        id_column="instance_id",
+        data_column="problem_statement",
+    )
+
+    # Get all entries for the split.
+    entries = get_all_entries(split)
+
+    for entry in entries:
+        print(f"Processing system {entry}...")
+        try:
+            system = Evaluation.from_github(split, entry)
+        except ValueError as e:
+            print(f"Skipping {entry}: {e}")
+            continue
+
+        data = pd.DataFrame(
+            [
+                {
+                    **prediction.model_dump(),
+                    "resolved": system.results.is_resolved(prediction.instance_id),
+                }
+                for prediction in system.predictions
+            ]
+        )
+
+        # Some systems have duplicated entries, which Zeno doesn't like.
+        if len(data["instance_id"].unique()) != len(data["instance_id"]):
+            print(f"{entry} has duplicated entries.")
+            data.drop_duplicates("instance_id", inplace=True)
+
+        viz_project.upload_system(
+            data,
+            name=entry,
+            id_column="instance_id",
+            output_column="patch",
+        )
+
+
+if __name__ == "__main__":
+    main()  # pylint: disable=no-value-for-parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ package-mode = false
 python = "^3.12"
 zeno-client = "^0.1.16"
 swe-bench = {git = "https://github.com/csmith49/swe-bench.git"}
-
+click = "^8.1.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+python = "^3.12"
+zeno-client = "^0.1.16"
+swe-bench = {git = "https://github.com/csmith49/swe-bench.git"}
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-zeno-client


### PR DESCRIPTION
This PR adds a script that scrapes the SWE-bench leaderboard data from their [experiments repo](https://github.com/swe-bench/experiments) and generates a ZenoML project rendering the results.

Build the dependencies with `poetry install` and see the command-line arguments with:

```python
python leaderboard_to_zeno.py --help
```

## Caveats

The added script relies on calls to the Github API to find current leaderboard entries. Rate-limiting means you'll run into errors if you try to run the script more than 60 times an hour.

The script does _no_ visualization of trajectories. The metadata per-project gives an S3 address for the trajectories but I don't believe those are publicly available (if they are, I haven't managed to figure out the permissions).

## Why another script?

I keep running out of disk space and wanted a mechanism to generate the leaderboard visualization without breaking existing workflows or downloading a bunch of data.

## Other changes

* Moves `requirements.txt` to `pyproject.toml` and adds `poetry` configuration. This allows dependencies on [Github-hosted modules](https://github.com/csmith49/swe-bench) instead of PyPi.
* Standard Python extensions to the `.gitignore`.